### PR TITLE
Allow different title colors from Aqua

### DIFF
--- a/modal_form.go
+++ b/modal_form.go
@@ -11,6 +11,12 @@ type ModalForm struct {
 
 // NewModalForm implements a modal that can take in a custom form.
 func NewModalForm(title string, form *Form) *ModalForm {
+	return NewModalFormWithColor(title, form, tcell.ColorAqua)
+}
+
+// NewModalFormWithColor implements a modal that can take in a custom form that
+// allows setting the title color.
+func NewModalFormWithColor(title string, form *Form, fgColor tcell.Color) *ModalForm {
 	m := ModalForm{NewModal()}
 	m.form = form
 	m.form.SetBackgroundColor(Styles.ContrastBackgroundColor).SetBorderPadding(0, 0, 0, 0)
@@ -24,7 +30,7 @@ func NewModalForm(title string, form *Form) *ModalForm {
 		SetBackgroundColor(Styles.ContrastBackgroundColor).
 		SetBorderPadding(1, 1, 1, 1)
 	m.frame.SetTitle(title)
-	m.frame.SetTitleColor(tcell.ColorAqua)
+	m.frame.SetTitleColor(fgColor)
 	m.focus = m
 
 	return &m


### PR DESCRIPTION
This will enable k9s themes to use a different title color other than
Aqua. The default still creates the traditional Aqua title.

The Styles.BackgroundColor could be overridden too, but it never
gets used since it will be overridden by the background color of the
form which is exposed.

Here's an example of the change where the top image is new (and has a Crimson title of <Drain>), bottom has the static cyan. The white vs magenta text in the body is unrelated to this PR and is related to some of my other theming WIP tweaks in derailed/k9s#1149.
![image](https://user-images.githubusercontent.com/72811/121801007-ece52680-cc2c-11eb-82b6-26913de7409c.png)


This is related to derailed/k9s#1149