### PR TITLE
Fix dropdown styling

### DIFF
--- a/grid.go
+++ b/grid.go
@@ -418,9 +418,6 @@ func (g *Grid) Draw(screen tcell.Screen) {
 			row = g.rows[index]
 		}
 		if row > 0 {
-			if row < g.minHeight {
-				row = g.minHeight
-			}
 			continue // Not proportional. We already know the width.
 		} else if row == 0 {
 			row = 1
@@ -441,9 +438,6 @@ func (g *Grid) Draw(screen tcell.Screen) {
 			column = g.columns[index]
 		}
 		if column > 0 {
-			if column < g.minWidth {
-				column = g.minWidth
-			}
 			continue // Not proportional. We already know the height.
 		} else if column == 0 {
 			column = 1


### PR DESCRIPTION
Adds remaining code from upstream where dropdown styling was added. Missed this part of the upstream repo's commit when referencing https://github.com/rivo/tview/commit/29d673af0ce2281f8b517d1bd14aab453b8fc8ef, I had thought it was unrelated. This PR is a direct follow-up to #3 .

Seems to impact subtle styling. Without this change, I am unable to change some parts of a list's styling. I.e. I set unselected fg & bg + selected fg & bg, but only the selected fg style applies.