### PR TITLE
Attach method to set color to *ModalForm

### DIFF
--- a/modal_form.go
+++ b/modal_form.go
@@ -63,3 +63,7 @@ func (m *ModalForm) Draw(screen tcell.Screen) {
 	m.frame.SetRect(x, y, width, height)
 	m.frame.Draw(screen)
 }
+
+func (m *ModalForm) SetTitleColor(c tcell.Color) {
+	m.frame.SetTitleColor(c)
+}


### PR DESCRIPTION
The aim of this PR is to help to fix an issue in k9s to when spawning modal forms. An example can be found [here](https://github.com/derailed/k9s/blob/master/internal/view/scale_extender.go#L57), where the `NewModalForm` function hardcodes the title color to `tcell.ColorAqua`.

A skin where everything is set on black, taken from [here](https://github.com/derailed/k9s/issues/1951), shows that the title's color remains hardcoded, despite me setting manually in the k9s code the title color to red. This is a ss from the scale command from scale extender:
<img width="1100" alt="image" src="https://github.com/derailed/tview/assets/30158449/958ba6f7-6513-4696-869e-e4a4ea588d03">


Calling `confirm.SetTitleColor(whateverColor)` does not seem to work as the call does not target same destination as `confirm.frame.SetTitleColor` (which is the fix). 

In order to not change to signature of `NewModalForm` I attached the function that can help solve the issue and allow configuration of title color in k9s.