### PR TITLE
Change behavior of left and right keys to scroll faster horizontally

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -1255,9 +1255,9 @@ func (t *TextView) InputHandler() func(event *tcell.EventKey, setFocus func(p Pr
 		case tcell.KeyDown, tcell.KeyCtrlE:
 			t.lineOffset++
 		case tcell.KeyLeft:
-			t.columnOffset--
+			t.columnOffset -= 30
 		case tcell.KeyRight:
-			t.columnOffset++
+			t.columnOffset += 30
 		case tcell.KeyPgDn:
 			t.lineOffset += t.pageSize
 		case tcell.KeyCtrlF:


### PR DESCRIPTION
Sometimes one wants to show a pods log in k9s without word wrap (possibly it messes with the formatting).  k9s already allows for left-right movement to show the remainder of log lines however it goes one character at a time and is painfully slow for long lines.  This minor change moves 30 chars at a time and makes the log behave more like 'less -S' does with long lines.

Behavior of 'h' and 'l' keys remains unchanged.